### PR TITLE
Fixes crontab throwing errors when tmux isn't running

### DIFF
--- a/git-autofetch.tmux
+++ b/git-autofetch.tmux
@@ -135,32 +135,27 @@ install() {
   echo "Install is done"
 }
 
-# Checks if we are in tmux, and if we are, it will continue to the switch statement
-check_tmux
-tmux_valid=$
-if [ "$tmux_valid" ]; then
-  case "$1" in
-  "--current")
-    check_current
-    ;;
-  "--scan-paths")
-    scan_paths
-    ;;
-  "--add-cron")
-    add_cron_job
-    ;;
-  "--add-hook")
-    add_shell_hook
-    ;;
-  "--install")
-    install
-    ;;
-  "")
-    install
-    ;;
-  *)
-    echo "Invalid option: [$1]" >&2
-    exit 0
-    ;;
-  esac
-fi
+case "$1" in
+"--current")
+  check_current
+  ;;
+"--scan-paths")
+  scan_paths
+  ;;
+"--add-cron")
+  add_cron_job
+  ;;
+"--add-hook")
+  add_shell_hook
+  ;;
+"--install")
+  install
+  ;;
+"")
+  install
+  ;;
+*)
+  echo "Invalid option: [$1]" >&2
+  exit 0
+  ;;
+esac

--- a/git-autofetch.tmux
+++ b/git-autofetch.tmux
@@ -136,7 +136,9 @@ install() {
 }
 
 # Checks if we are in tmux, and if we are, it will continue to the switch statement
-if [ "$check_tmux" ]; then
+check_tmux
+tmux_valid=$
+if [ "$tmux_valid" ]; then
   case "$1" in
   "--current")
     check_current

--- a/git-autofetch.tmux
+++ b/git-autofetch.tmux
@@ -11,127 +11,145 @@ SCAN_PATHS=${SCAN_PATHS/\~/$HOME}
 FETCH_FREQUENCY_MINS=3
 
 log() {
-    [ ! "$LOGGING" = "true" ] && return 0;
-    local f=${FUNCNAME[1]}
-    local r="$2"
-    local l="/tmp/tmux-git-autofetch.log"
-    [ "$1" = "sep" ] && echo "---" >> $l && return 0;
-    [ "$f" = "path_control" ] && (echo "┌ Patterns => Skip: $SKIP_PATHS - Scan: $SCAN_PATHS") >> $l;
-    local res=$([[ -n "$r" ]] && echo "true" || echo "false")
-    echo "$(date +'%Y-%m-%d-%H:%M:%S') [$f] $1 => $res" >> $l;
-    [ "$f" = "fetch" ] && awk '{sub("^", "├ "); print}' "$1/.git/FETCH_HEAD" >> $l;
+  [ ! "$LOGGING" = "true" ] && return 0
+  local f=${FUNCNAME[1]}
+  local r="$2"
+  local l="/tmp/tmux-git-autofetch.log"
+  [ "$1" = "sep" ] && echo "---" >>$l && return 0
+  [ "$f" = "path_control" ] && (echo "┌ Patterns => Skip: $SKIP_PATHS - Scan: $SCAN_PATHS") >>$l
+  local res=$([[ -n "$r" ]] && echo "true" || echo "false")
+  echo "$(date +'%Y-%m-%d-%H:%M:%S') [$f] $1 => $res" >>$l
+  [ "$f" = "fetch" ] && awk '{sub("^", "├ "); print}' "$1/.git/FETCH_HEAD" >>$l
 }
 
 fetch() {
-    local res=$(cd "$1" && git fetch -q --all && echo "true")
-    log "$1" "$res"&
+  local res=$(cd "$1" && git fetch -q --all && echo "true")
+  log "$1" "$res" &
 }
 
 path_control() {
-    local pass=0
-    [[ $1 =~ $SKIP_PATHS ]] && pass=1;
-    [[ $1 =~ $SCAN_PATHS ]] && pass=0;
-    log "sep"
-    log "$1" "$([ "$pass" = 0 ] && echo "true")"
-    return "$pass"
+  local pass=0
+  [[ $1 =~ $SKIP_PATHS ]] && pass=1
+  [[ $1 =~ $SCAN_PATHS ]] && pass=0
+  log "sep"
+  log "$1" "$([ "$pass" = 0 ] && echo "true")"
+  return "$pass"
 }
 
 get_repo_root() {
-    local path="$1"
-    local repo_root=$(cd "$path" && git rev-parse --show-toplevel 2>/dev/null)
-    echo "$repo_root"
+  local path="$1"
+  local repo_root=$(cd "$path" && git rev-parse --show-toplevel 2>/dev/null)
+  echo "$repo_root"
 }
 
 # Control fetch if it's repo & time is reached
 path_should_fetch() {
-    repo_root_path=$(get_repo_root "$1")
-    [ -z "$repo_root_path" ] && exit 1;
+  repo_root_path=$(get_repo_root "$1")
+  [ -z "$repo_root_path" ] && exit 1
 
-    id=$(echo "$repo_root_path" | sed 's|/|_|g')
-    cache_path="/tmp/tmux-git-autofetch-cache/"
-    time_file="$cache_path$id"
-    time_file_new=false
-    [ ! -d "$cache_path" ] && mkdir "$cache_path"
-    [ ! -e "$time_file" ] && { touch "$time_file"; time_file_new=true; }
+  id=$(echo "$repo_root_path" | sed 's|/|_|g')
+  cache_path="/tmp/tmux-git-autofetch-cache/"
+  time_file="$cache_path$id"
+  time_file_new=false
+  [ ! -d "$cache_path" ] && mkdir "$cache_path"
+  [ ! -e "$time_file" ] && {
+    touch "$time_file"
+    time_file_new=true
+  }
 
-    now=$(date +%s)
-    scanned=$(date -r "$time_file" "+%s")
-    diff=$((now - scanned))
-    mins_ago=$((diff / 60))
-    should_fetch=$(((mins_ago && mins_ago >= FETCH_FREQUENCY_MINS) || time_file_new))
+  now=$(date +%s)
+  scanned=$(date -r "$time_file" "+%s")
+  diff=$((now - scanned))
+  mins_ago=$((diff / 60))
+  should_fetch=$(((mins_ago && mins_ago >= FETCH_FREQUENCY_MINS) || time_file_new))
 
-    if [ "$should_fetch" -eq 1 ]; then
-        log "Checked more than $FETCH_FREQUENCY_MINS minutes ago ($mins_ago: $diff s). Should scan" $should_fetch
-        touch -t "$(date +"%Y%m%d%H%M.%S")" "$time_file"
-    else
-        log "Checked less than $FETCH_FREQUENCY_MINS minutes ago ($mins_ago: $diff s). Skip"
-    fi
-    [ "$should_fetch" -eq 1 ]
+  if [ "$should_fetch" -eq 1 ]; then
+    log "Checked more than $FETCH_FREQUENCY_MINS minutes ago ($mins_ago: $diff s). Should scan" $should_fetch
+    touch -t "$(date +"%Y%m%d%H%M.%S")" "$time_file"
+  else
+    log "Checked less than $FETCH_FREQUENCY_MINS minutes ago ($mins_ago: $diff s). Skip"
+  fi
+  [ "$should_fetch" -eq 1 ]
 }
 
 # Check changed path
 check_current() {
-    path="${1-$(pwd)}"
-    path_control "$path" &&
+  path="${1-$(pwd)}"
+  path_control "$path" &&
     path_should_fetch "$path" &&
     fetch "$path"
 }
 
 # Fetch current opened repositories
 scan_paths() {
-    tmux_panes_paths=$(tmux list-windows -F '#{pane_current_path}' | sort | uniq)
-    for path in $tmux_panes_paths; do
-        [ -d $path ] && check_current $path;
-    done
+  tmux_panes_paths=$(tmux list-windows -F '#{pane_current_path}' | sort | uniq)
+  for path in $tmux_panes_paths; do
+    [ -d $path ] && check_current $path
+  done
 }
 
 # Cron job to keep scanning
 add_cron_job() {
-    script_file_path="$(readlink -f "$0")"
-    if ! crontab -l | grep -q "$script_file_path"; then
-        (crontab -l | { cat; echo "*/1 * * * * $script_file_path --scan-paths"; } | crontab -) &&
-        echo "Added cron job";
-    else
-        echo "Cron already exists";
-    fi
+  script_file_path="$(readlink -f "$0")"
+  if ! crontab -l | grep -q "$script_file_path"; then
+    (crontab -l | {
+      cat
+      echo "*/1 * * * * $script_file_path --scan-paths"
+    } | crontab -) &&
+      echo "Added cron job"
+  else
+    echo "Cron already exists"
+  fi
 }
 
 # To check when changing directory
 add_shell_hook() {
-    if grep -qE "^[^#]*tmux-git-autofetch/" ~/.zshrc; then
-        echo "Shell hook already exists";
-        return 0;
-    fi
-    script_file_path="$(readlink -f "$0")"
-    cp ~/.zshrc ~/.zshrc.bk_tga &&
+  if grep -qE "^[^#]*tmux-git-autofetch/" ~/.zshrc; then
+    echo "Shell hook already exists"
+    return 0
+  fi
+  script_file_path="$(readlink -f "$0")"
+  cp ~/.zshrc ~/.zshrc.bk_tga &&
     echo "
-tmux-git-autofetch() {($script_file_path --current &)}
+tmux-git-autofetch() {
+
+if [ \"$TERM_PROGRAM\" = tmux ]; then 
+  ($script_file_path --current &)
+fi
+
+}
 add-zsh-hook chpwd tmux-git-autofetch
-    " >> ~/.zshrc &&
+    " >>~/.zshrc &&
     echo "Added shell hook"
 }
 
 install() {
-    add_cron_job
-    add_shell_hook
-    echo "Install is done"
+  add_cron_job
+  add_shell_hook
+  echo "Install is done"
 }
 
 case "$1" in
-    "--current")
-        check_current ;;
-    "--scan-paths")
-        scan_paths ;;
-    "--add-cron")
-        add_cron_job ;;
-    "--add-hook")
-        add_shell_hook ;;
-    "--install")
-        install ;;
-    "")
-        install ;;
-    *)
-        echo "Invalid option: [$1]" >&2
-        exit 0 ;;
+"--current")
+  check_current
+  ;;
+"--scan-paths")
+  scan_paths
+  ;;
+"--add-cron")
+  add_cron_job
+  ;;
+"--add-hook")
+  add_shell_hook
+  ;;
+"--install")
+  install
+  ;;
+"")
+  install
+  ;;
+*)
+  echo "Invalid option: [$1]" >&2
+  exit 0
+  ;;
 esac
-

--- a/git-autofetch.tmux
+++ b/git-autofetch.tmux
@@ -102,7 +102,7 @@ add_cron_job() {
   if ! crontab -l | grep -q "$script_file_path"; then
     (crontab -l | {
       cat
-      echo "*/1 * * * * $script_file_path --scan-paths"
+      echo "*/1 * * * * pgrep -x \"tmux\" > /dev/null && $script_file_path --scan-paths"
     } | crontab -) &&
       echo "Added cron job"
   else


### PR DESCRIPTION
Previously, when the plugin was installed, changing directories or every couple minutes it would throw an error because there wasn't any tmux session. So I did this:

If you run `echo $TERM_PROGRAM` in tmux, the value will be `tmux`

So first commit I did was to test this fix to see if it works on one function, so then I implemented it in a function and put them for everything: 

```bash
# Check if we are in tmux
check_tmux() {
  if [ "$TERM_PROGRAM" = "tmux" ]; then
    true
  else
    false
  fi
}
```

_That's all! Tested on my Mac-book M1 Pro, running Mac OS V15.0 beta_